### PR TITLE
Design improvements, fix slide order bug

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,12 @@
 import React from "react";
 import Layout from "./src/layout/Layout";
+import GlobalStyles from "./src/components/GlobalStyles";
 
 export const wrapPageElement = ({ element, props }) => {
-  return <Layout {...props}>{element}</Layout>;
+  return (
+    <>
+      <GlobalStyles />
+      <Layout {...props}>{element}</Layout>
+    </>
+  );
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,7 +3,7 @@ module.exports = {
   siteMetadata: {
     title: `Kevin C Maginnis`,
     titleTemplate: "Kevin C Maginnis | %s",
-    siteUrl: `https://aesthetic-bienenstitch-01eb0a.netlify.app`,
+    siteUrl: `https://kevincmagnnis.netlify.app`,
   },
   plugins: [
     "gatsby-transformer-remark",

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,57 +1,8 @@
-exports.sourceNodes = ({
-  actions,
-  createNodeId,
-  createContentDigest,
-  getNodesByType,
-}) => {
-  const { createNode } = actions;
-
-  const slides = getNodesByType("SlidesYaml");
-
-  slides.forEach((slideNode, index) => {
-    const { title, year, artForm, slideCaption, slideMedia } = slideNode;
-    const data = {
-      title,
-      year,
-      artForm: artForm || null,
-      mediaFileName: slideMedia.fileName,
-      caption: slideCaption || null,
-    };
-
-    createNode({
-      id: createNodeId(`slide-${index}-${title}`),
-      parent: null,
-      children: [],
-      internal: {
-        type: "ArtworkSlide",
-        contentDigest: createContentDigest(data),
-      },
-      ...data,
-    });
-  });
-};
-
-exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions;
-
-  const typeDefs = [
-    `type ArtworkSlide implements Node {
-      title: String!
-      year: Int!
-      artForm: String
-      caption: String
-      mediaFileName: String
-      imageFile: File
-    }`,
-  ];
-
-  createTypes(typeDefs);
-};
-
 exports.createResolvers = ({ createResolvers }) => {
   createResolvers({
-    ArtworkSlide: {
+    SlidesYaml: {
       imageFile: {
+        type: "File",
         resolve: async (source, __args, context) => {
           const { nodeModel } = context;
           const imageFileNode = await nodeModel.findOne({
@@ -59,7 +10,7 @@ exports.createResolvers = ({ createResolvers }) => {
             query: {
               filter: {
                 base: {
-                  eq: source.mediaFileName,
+                  eq: source.slideMedia.fileName,
                 },
                 sourceInstanceName: {
                   eq: "artworkImages",

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,3 @@
-const ARTWORK_SLIDES_PATH_PREFIX = "src/artwork-slides/";
-const path = require("path");
-
 exports.sourceNodes = ({
   actions,
   createNodeId,

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,6 +1,26 @@
 import React from "react";
 import Layout from "./src/layout/Layout";
+import GlobalStyles from "./src/components/GlobalStyles";
 
 export const wrapPageElement = ({ element, props }) => {
-  return <Layout {...props}>{element}</Layout>;
+  return (
+    <>
+      <GlobalStyles />
+      <Layout {...props}>{element}</Layout>
+    </>
+  );
+};
+
+export const onPreRenderHTML = ({
+  getHeadComponents,
+  replaceHeadComponents,
+}) => {
+  replaceHeadComponents([
+    ...getHeadComponents(),
+    <link
+      key="open-sans"
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@200&display=swap"
+    />,
+  ]);
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gatsby-transformer-remark": "^5.23.0",
     "gatsby-transformer-sharp": "^4.23.0",
     "gatsby-transformer-yaml": "^4.25.0",
+    "polished": "^4.2.2",
     "prop-types": "^15.8.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -12,6 +12,9 @@ const GlobalStyles = () => (
       :root {
         ${variables};
         ${typography};
+
+        --site-content-padding: 2rem 2rem 0 2rem;
+        --site-max-width: 1260px;
       }
 
       * {
@@ -21,8 +24,8 @@ const GlobalStyles = () => (
       body {
         font-size: 16px;
         font-family: var(--primary-font-family);
-        color: var(--primary-text-color);
-        background-color: var(--primary-background-color);
+        color: #515151;
+        background-color: #fff;
         line-height: 1.5;
       }
 

--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { normalize } from "polished";
+import { Global, css } from "@emotion/react";
+import typography from "./typography";
+import variables from "./variables";
+
+const GlobalStyles = () => (
+  <Global
+    styles={css`
+      ${normalize()}
+
+      :root {
+        ${variables};
+        ${typography};
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        font-size: 16px;
+        font-family: var(--primary-font-family);
+        color: var(--primary-text-color);
+        background-color: var(--primary-background-color);
+        line-height: 1.5;
+      }
+
+      a {
+        cursor: pointer;
+        color: var(--link-color);
+        transition: 0.2s ease-out;
+
+        &:hover {
+          color: var(--link-hover-color);
+        }
+      }
+
+      p {
+        margin-top: 0;
+        margin-bottom: var(--paragraph-spacing);
+        line-height: 1.75;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
+      h1 {
+        line-height: 1.15;
+        font-weight: bold;
+        margin-bottom: 1rem;
+      }
+
+      h2 {
+        line-height: 1.25;
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+      }
+
+      h3 {
+        margin-bottom: 0.75rem;
+        font-weight: 600;
+      }
+    `}
+  />
+);
+
+export default GlobalStyles;

--- a/src/components/GlobalStyles/index.js
+++ b/src/components/GlobalStyles/index.js
@@ -1,0 +1,1 @@
+export { default } from "./GlobalStyles";

--- a/src/components/GlobalStyles/typography.js
+++ b/src/components/GlobalStyles/typography.js
@@ -1,0 +1,7 @@
+import { css } from "@emotion/react";
+
+export default css`
+  --primary-font-family: "Nunito Sans", system-ui, sans-serif;
+
+  --paragraph-spacing: 1.25rem;
+`;

--- a/src/components/GlobalStyles/variables.js
+++ b/src/components/GlobalStyles/variables.js
@@ -2,4 +2,6 @@ import { css } from "@emotion/react";
 
 export default css`
   --global-header-height: auto;
+
+  --link-hover-color: blue;
 `;

--- a/src/components/GlobalStyles/variables.js
+++ b/src/components/GlobalStyles/variables.js
@@ -1,0 +1,5 @@
+import { css } from "@emotion/react";
+
+export default css`
+  --global-header-height: auto;
+`;

--- a/src/components/NavMenu/NavItem.js
+++ b/src/components/NavMenu/NavItem.js
@@ -1,0 +1,31 @@
+/** @jsx jsx */
+import React from "react";
+import { css, jsx } from "@emotion/react";
+import { Link } from "gatsby";
+
+const NavItem = ({ to, text, location }) => {
+  const isCurrent = to === location.pathname;
+
+  const style = css`
+    color: ${isCurrent ? "red" : "auto"};
+    text-decoration: none;
+    text-transform: uppercase;
+    :hover {
+      color: red;
+    }
+  `;
+  return (
+    <li
+      css={css`
+        padding: 0.5em 0 0.5em 1em;
+        border-left: ${isCurrent ? "2px solid red" : "none"};
+      `}
+    >
+      <Link css={style} to={to}>
+        {text}
+      </Link>
+    </li>
+  );
+};
+
+export default NavItem;

--- a/src/components/NavMenu/NavMenu.js
+++ b/src/components/NavMenu/NavMenu.js
@@ -1,0 +1,21 @@
+/** @jsx jsx */
+import React from "react";
+import { css, jsx } from "@emotion/react";
+import NavItem from "./NavItem";
+
+const NavMenu = ({ location }) => {
+  return (
+    <nav
+      css={css`
+        list-style-type: none;
+      `}
+    >
+      <NavItem to="/" text="Artwork" location={location} />
+      <NavItem to="/bio/" text="Bio" location={location} />
+      <NavItem to="/contact/" text="Contact" location={location} />
+      <NavItem to="/cv/" text="CV" location={location} />
+    </nav>
+  );
+};
+
+export default NavMenu;

--- a/src/layout/Header.js
+++ b/src/layout/Header.js
@@ -7,6 +7,7 @@ const Header = () => {
     <>
       <div
         css={css`
+          padding: var(--site-content-padding);
           display: flex;
           justify-content: flex-start;
           flex-wrap: wrap;
@@ -14,10 +15,19 @@ const Header = () => {
           font-weight: 300;
           letter-spacing: 0.5em;
           text-transform: uppercase;
+          > * {
+            margin-right: 1em;
+          }
         `}
       >
         <div>Kevin</div>
-        <div>C</div>
+        <div
+          css={css`
+            color: red;
+          `}
+        >
+          C
+        </div>
         <div>Maginnis</div>
       </div>
     </>

--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -8,7 +8,12 @@ import Sidebar from "./Sidebar";
 
 const Layout = ({ children }) => {
   return (
-    <>
+    <div
+      css={css`
+        max-width: var(--site-max-width);
+        margin: 0 auto;
+      `}
+    >
       <Header />
       <div
         css={css`
@@ -30,7 +35,7 @@ const Layout = ({ children }) => {
           <Content>{children}</Content>
         </Main>
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -6,7 +6,7 @@ import Main from "./Main";
 import Content from "./Content";
 import Sidebar from "./Sidebar";
 
-const Layout = ({ children }) => {
+const Layout = ({ children, location }) => {
   return (
     <div
       css={css`
@@ -30,7 +30,7 @@ const Layout = ({ children }) => {
           }
         `}
       >
-        <Sidebar />
+        <Sidebar location={location} />
         <Main>
           <Content>{children}</Content>
         </Main>

--- a/src/layout/Sidebar.js
+++ b/src/layout/Sidebar.js
@@ -2,8 +2,9 @@
 import React from "react";
 import { css, jsx } from "@emotion/react";
 import { Link } from "gatsby";
+import NavMenu from "../components/NavMenu/NavMenu";
 
-const Sidebar = () => {
+const Sidebar = ({ location }) => {
   return (
     <aside
       css={css`
@@ -14,16 +15,7 @@ const Sidebar = () => {
         }
       `}
     >
-      <nav>
-        <li>
-          <Link to="/">Artwork</Link>
-        </li>
-        <li>
-          <Link to="/bio/">Bio</Link>
-        </li>
-        <li>Contact</li>
-        <li>CV</li>
-      </nav>
+      <NavMenu location={location} />
     </aside>
   );
 };

--- a/src/layout/Sidebar.js
+++ b/src/layout/Sidebar.js
@@ -7,6 +7,7 @@ const Sidebar = () => {
   return (
     <aside
       css={css`
+        padding: var(--site-content-padding);
         grid-area: sidebar;
         @media screen and (max-width: 760px) {
           display: none;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -6,10 +6,10 @@ import { useTransition, animated, useSpringRef } from "@react-spring/web";
 
 const HomePage = ({ data }) => {
   const {
-    allArtworkSlide: { nodes: slides },
+    allSlidesYaml: { nodes: slides },
   } = data;
 
-  const pages = slides.map(({ caption, imageFile }) => ({ style }) => (
+  const pages = slides.map(({ slideCaption, imageFile }) => ({ style }) => (
     <animated.div style={{ ...style }}>
       <div
         css={css`
@@ -17,14 +17,14 @@ const HomePage = ({ data }) => {
         `}
       >
         <img
-          alt={caption}
+          alt={slideCaption}
           css={css`
             max-width: 100%;
           `}
           src={imageFile.childImageSharp.fluid.src}
         />
       </div>
-      <p>{caption}</p>
+      <p>{slideCaption}</p>
     </animated.div>
   ));
 
@@ -84,10 +84,10 @@ export default HomePage;
 
 export const query = graphql`
   query SlideQuery {
-    allArtworkSlide {
+    allSlidesYaml {
       nodes {
         artForm
-        caption
+        slideCaption
         imageFile {
           childImageSharp {
             fluid(maxWidth: 800) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1027,7 +1027,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.0", "@babel/runtime@^7.20.7":
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.17.8", "@babel/runtime@^7.20.7":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -8792,6 +8792,13 @@ platform@^1.3.6:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
+
+polished@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-4.2.2.tgz#2529bb7c3198945373c52e34618c8fe7b1aa84d1"
+  integrity sha512-Sz2Lkdxz6F2Pgnpi9U5Ng/WdWAUZxmHrNPoVlm3aAemxoy2Qy7LGjQg4uf8qKelDAUW94F4np3iH2YPf2qefcQ==
+  dependencies:
+    "@babel/runtime" "^7.17.8"
 
 postcss-calc@^8.2.3:
   version "8.2.4"


### PR DESCRIPTION
## Description

- Adds global styles & components
  - Includes adding some padding, max width
  - Updates header text
  - Updates nav menu to look like current one, including current page indicator
- Adds ability to bring in different fonts. Currently just a google font. Need to add custom gil sans in follow up PR
- Fixes bug where artwork slides were not presented in same order as slides.yaml file.
  - This was due to querying for all nodes of type `SlidesYaml` via `getNodesByType()` action. This apparently returns an array in different order than `allSlidesYaml` which sources and keeps order from slides.yaml. This PR just adds a field directly in the `SlidesYaml` node and resolves to relevant artwork image.

## Related
Related to https://github.com/roadlittledawn/kevincmaginnis/issues/13 