### PR TITLE
Clang/fix slide show x scroll

### DIFF
--- a/src/components/SlideShow.js
+++ b/src/components/SlideShow.js
@@ -36,12 +36,13 @@ const SlideShow = ({
       css={css`
         text-align: center;
         overflow: hidden;
-        height: ${slides[index].imageFile
+        height: auto;
+        /* height: ${slides[index].imageFile
           ? `${
               slides[index].imageFile.childImageSharp.fluid.presentationHeight +
               80
             }px`
-          : "auto"};
+          : "auto"}; */
         /* @media screen and (max-width: ${SITE_OPTIONS.mobileBreakpoint}) {
           height: auto;
         } */
@@ -54,8 +55,6 @@ const SlideShow = ({
             key={`slide-${i}`}
             css={css`
               opacity: ${isShown ? 1 : 0};
-              /* position: absolute; */
-              /* display: ${isShown ? "block" : "none"}; */
               transform: ${isShown ? "translateX(0px)" : "translateX(9999px)"};
               transition: opacity 1s ease-in-out 0.1s;
             `}
@@ -67,6 +66,7 @@ const SlideShow = ({
                 `}
               >
                 <img
+                  style={{ position: isShown ? "static" : "absolute" }}
                   css={css`
                     position: absolute;
                     right: 0;
@@ -95,9 +95,10 @@ const SlideShow = ({
             <div
               style={{
                 display: isShown ? "block" : "none",
-                // position: "absolute",
                 position:
-                  slide.slideMedia.type === "image" ? "absolute" : "relative",
+                  slide.slideMedia.type === "image" && isShown
+                    ? "static"
+                    : "relative",
                 top: slide.imageFile
                   ? `${slide.imageFile.childImageSharp.fluid.presentationHeight}px`
                   : `auto`,

--- a/src/components/SlideShow.js
+++ b/src/components/SlideShow.js
@@ -37,15 +37,6 @@ const SlideShow = ({
         text-align: center;
         overflow: hidden;
         height: auto;
-        /* height: ${slides[index].imageFile
-          ? `${
-              slides[index].imageFile.childImageSharp.fluid.presentationHeight +
-              80
-            }px`
-          : "auto"}; */
-        /* @media screen and (max-width: ${SITE_OPTIONS.mobileBreakpoint}) {
-          height: auto;
-        } */
       `}
     >
       {slides.map((slide, i) => {

--- a/src/components/SlideShow.js
+++ b/src/components/SlideShow.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import { css, jsx } from "@emotion/react";
 import PropTypes from "prop-types";
 import Video from "./Video";
+import { SITE_OPTIONS } from "../utils/contants";
 
 const SlideShow = ({
   slides,
@@ -33,11 +34,17 @@ const SlideShow = ({
   return (
     <div
       css={css`
-        position: relative;
         text-align: center;
+        overflow: hidden;
         height: ${slides[index].imageFile
-          ? `${slides[index].imageFile.childImageSharp.fluid.presentationHeight}px`
+          ? `${
+              slides[index].imageFile.childImageSharp.fluid.presentationHeight +
+              80
+            }px`
           : "auto"};
+        /* @media screen and (max-width: ${SITE_OPTIONS.mobileBreakpoint}) {
+          height: auto;
+        } */
       `}
     >
       {slides.map((slide, i) => {
@@ -47,6 +54,8 @@ const SlideShow = ({
             key={`slide-${i}`}
             css={css`
               opacity: ${isShown ? 1 : 0};
+              /* position: absolute; */
+              /* display: ${isShown ? "block" : "none"}; */
               transform: ${isShown ? "translateX(0px)" : "translateX(9999px)"};
               transition: opacity 1s ease-in-out 0.1s;
             `}
@@ -85,7 +94,10 @@ const SlideShow = ({
             )}
             <div
               style={{
-                position: "absolute",
+                display: isShown ? "block" : "none",
+                // position: "absolute",
+                position:
+                  slide.slideMedia.type === "image" ? "absolute" : "relative",
                 top: slide.imageFile
                   ? `${slide.imageFile.childImageSharp.fluid.presentationHeight}px`
                   : `auto`,


### PR DESCRIPTION
## Description

Fixes a couple nagging issues:
* on smaller screens captions are now right under max width image instead of at bottom of slide show container (which was based on original image height)
* fixes issue where overflow on X or Y axis added lots of blank space and scrollable area due to image styles not being fully hidden from content layout