### PR TITLE
fix: set mobile nav open to false when location changes

### DIFF
--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -1,5 +1,5 @@
 /** @jsx jsx */
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { css, jsx } from "@emotion/react";
 import Header from "./Header";
 import Main from "./Main";
@@ -11,6 +11,7 @@ import { SITE_OPTIONS } from "../utils/contants";
 
 const Layout = ({ children, location }) => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  useEffect(() => setIsMobileNavOpen(false), [location]);
   return (
     <div
       css={css`


### PR DESCRIPTION
## Description

Fixes issue where if mobile nav is opened and a page is navigated to, menu stays open. User must dismiss in order to view page content.

Instead the nav menu should close once a page is navigaeted to / menu item is clicked

## Screenshot(s)

https://github.com/roadlittledawn/kevincmaginnis/assets/2952843/27bee6ab-8123-4aad-9013-3c0ae4984498



